### PR TITLE
Changing stop command

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -143,7 +143,8 @@ sessions where you ran the system and inventory services.
 Alternatively, you can run the `liberty:stop` goal from the `finish` directory in another command-line session:
 [role="command"]
 ----
-mvn liberty:stop
+ mvn -pl system liberty:stop
+ mvn -pl inventory liberty:stop
 ----
 
 // =================================================================================================

--- a/README.adoc
+++ b/README.adoc
@@ -140,7 +140,7 @@ image::trace01.png[Finished application's trace,align="center"]
 
 After you’re finished reviewing the application, stop the Open Liberty servers by pressing `CTRL+C` in the command-line
 sessions where you ran the system and inventory services.
-Alternatively, you can run the `liberty:stop` goal from the `finish` directory in another command-line session:
+Alternatively, you can run the following goals from the `finish` directory in another command-line session:
 [role="command"]
 ----
  mvn -pl system liberty:stop


### PR DESCRIPTION
Running `mvn liberty:stop` from the `finish` directory returns an error. That command has been replaced with the following:
``` 
mvn -pl system liberty:stop
mvn -pl inventory liberty:stop
```

The changes can be see on the lgdev site (4020) for review. 